### PR TITLE
Fix interpolator to stop builds crashing

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "country-data": "^0.0.31",
     "countryinfo": "^1.0.3",
     "deep-equal": "^1.1.0",
+    "linear-interpolator": "^1.0.2",
     "lodash": "^4.17.15",
     "markdown-to-jsx": "^6.10.3",
     "qs": "^6.8.0",
@@ -21,8 +22,7 @@
     "react-dom": "^16.9.0",
     "react-intl": "^3.2.1",
     "react-router-dom": "^5.0.1",
-    "react-scripts": "3.1.1",
-    "simple-interpolation": "^1.0.6"
+    "react-scripts": "3.1.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/components/HowRichAmI/index.js
+++ b/src/components/HowRichAmI/index.js
@@ -236,6 +236,23 @@ const calculationStyles = theme => ({
   }
 })
 
+// <FormattedNumber /> requires a 'style' prop, but linters treat this as a reserved word. This is a workaround
+// see https://github.com/formatjs/formatjs/issues/785#issuecomment-360295980
+const FormattedCurrency = ({ style = 'currency', minimumFractionDigits = 0, maximumFractionDigits = 0, ...props }) => (
+  <FormattedNumber
+    style={style}
+    minimumFractionDigits={minimumFractionDigits}
+    maximumFractionDigits={maximumFractionDigits}
+    {...props}
+  />
+)
+
+FormattedCurrency.propTypes = {
+  style: PropTypes.string,
+  minimumFractionDigits: PropTypes.number,
+  maximumFractionDigits: PropTypes.number
+}
+
 const Calculation = withStyles(calculationStyles)(({ income, countryCode, household, classes }) => {
   try {
     const { incomeCentile, incomeTopPercentile, medianMultiple, equivalizedIncome } = calculate({ income, countryCode, household })
@@ -255,7 +272,7 @@ const Calculation = withStyles(calculationStyles)(({ income, countryCode, househ
       <Grid item xs={12}>
         <Typography className={classes.mainText}>
           If you have a household income of{' '}
-          <FormattedNumber value={income} style='currency' currency={getCurrencyCode(countryCode)} minimumFractionDigits={0} maximumFractionDigits={0} />
+          <FormattedCurrency value={income} currency={getCurrencyCode(countryCode)} />
         </Typography>
         <Typography className={classes.subMainText}>
           (in a household of {household.adults} adult{household.adults > 1 ? 's' : ''}
@@ -325,9 +342,9 @@ const DonationCalculation = withStyles(calculationStyles)(({ income, countryCode
       <Grid item sm={12}>
         <Typography className={classes.mainText}>
           … you would have a household income of{' '}
-          <FormattedNumber value={donationIncome} style='currency' currency={getCurrencyCode(countryCode)} minimumFractionDigits={0} maximumFractionDigits={0} />,{' '}
+          <FormattedCurrency value={donationIncome} currency={getCurrencyCode(countryCode)} />,{' '}
           and would make{' '}
-          <FormattedNumber value={donationAmount} style='currency' currency={getCurrencyCode(countryCode)} minimumFractionDigits={0} maximumFractionDigits={0} />{' '}
+          <FormattedCurrency value={donationAmount} currency={getCurrencyCode(countryCode)} />{' '}
           in donations …
         </Typography>
       </Grid>
@@ -509,7 +526,7 @@ const CallToAction = withStyles(callToActionStyles)(({ classes }) => <Grid conta
     <Grid container spacing={GRID_SPACING}>
       <Grid item xs={12}>
         <div className={classes.logoBackground}>
-          <img src='https://d33wubrfki0l68.cloudfront.net/18388e7f00903004ecbc40f3599d4989ca66fce3/f0c79/images/logos/gwwc-logo-transparent-nav.png' />
+          <img src='https://d33wubrfki0l68.cloudfront.net/18388e7f00903004ecbc40f3599d4989ca66fce3/f0c79/images/logos/gwwc-logo-transparent-nav.png' alt='GWWC logo' />
         </div>
       </Grid>
       <Grid item xs={12}>
@@ -709,7 +726,7 @@ export const HowRichAmIStandalone = withStyles(standaloneStyles)(({ classes }) =
     <Toolbar>
       <a href='https://givingwhatwecan.org'>
         <div className={classes.logoBackground}>
-          <img src='https://d33wubrfki0l68.cloudfront.net/18388e7f00903004ecbc40f3599d4989ca66fce3/f0c79/images/logos/gwwc-logo-transparent-nav.png' />
+          <img src='https://d33wubrfki0l68.cloudfront.net/18388e7f00903004ecbc40f3599d4989ca66fce3/f0c79/images/logos/gwwc-logo-transparent-nav.png' alt='GWWC logo' />
         </div>
       </a>
       <Typography variant='h6'>How Rich Am I?</Typography>

--- a/src/lib/calculate/index.js
+++ b/src/lib/calculate/index.js
@@ -1,5 +1,5 @@
 import { currencies } from 'countryinfo'
-import { single as interpolate } from 'simple-interpolation'
+import interpolate from 'linear-interpolator'
 import INCOME_CENTILES from './data/income_centiles.json'
 import PPP_CONVERSION from './data/ppp_conversion.json'
 import EXCHANGE_RATES from './data/exchange_rates.json'
@@ -8,15 +8,23 @@ import BigNumber from 'bignumber.js'
 export { COMPARISONS }
 
 // data interpolation
-const interpolateIncomeCentile = interpolate(
-  INCOME_CENTILES.map(centile => ({ x: centile.percentage, y: centile.international_dollars }))
+// const interpolateIncomeCentile = interpolate(
+//   INCOME_CENTILES.map(centile => ({ x: centile.percentage, y: centile.international_dollars }))
+// )
+
+const interpolateIncomeCentileByAmountInterpolator = interpolate(
+  INCOME_CENTILES.map(centile => ([centile.international_dollars, centile.percentage]))
 )
 
-export const interpolateIncomeCentileByAmount = amount => BigNumber(interpolateIncomeCentile({ y: amount }))
+const interpolateIncomeAmountByCentileInterpolator = interpolate(
+  INCOME_CENTILES.map(centile => ([centile.percentage, centile.international_dollars]))
+)
+
+export const interpolateIncomeCentileByAmount = amount => BigNumber(interpolateIncomeCentileByAmountInterpolator(amount))
   .decimalPlaces(1)
   .toNumber()
 
-export const interpolateIncomeAmountByCentile = centile => BigNumber(interpolateIncomeCentile({ x: centile }))
+export const interpolateIncomeAmountByCentile = centile => BigNumber(interpolateIncomeAmountByCentileInterpolator(centile))
   .decimalPlaces(2)
   .toNumber()
 

--- a/src/lib/calculate/index.test.js
+++ b/src/lib/calculate/index.test.js
@@ -18,8 +18,8 @@ import COMPARISONS from './data/comparisons.json'
 
 describe('income centile interpolation', () => {
   test('interpolateIncomeCentileByAmount is sane', () => {
-    const centile = interpolateIncomeCentileByAmount(21000)
-    expect(centile).toBeGreaterThan(90)
+    const centile = interpolateIncomeCentileByAmount(20000)
+    expect(centile).toBe(90.5)
   })
 
   test('interpolateIncomeAmountByCentile is sane', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6330,6 +6330,11 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+linear-interpolator@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/linear-interpolator/-/linear-interpolator-1.0.2.tgz#32646681ed406ef237c851b2c5e4b337eb9be5fa"
+  integrity sha1-MmRmge1AbvI3yFGyxeSzN+ub5fo=
+
 load-json-file@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"
@@ -9327,11 +9332,6 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
-
-simple-interpolation@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/simple-interpolation/-/simple-interpolation-1.0.6.tgz#f98d85fc5b317c51c3fb6f3a2435fde944379958"
-  integrity sha512-pXfssRDoTtda1Xz+qdrckh348rggIHE1ZpBWKGDaxGWQi2MxocDPbgIXPdV9FmsRs9zoDKZr6njB3OYkhU7llA==
 
 simple-swizzle@^0.2.2:
   version "0.2.2"


### PR DESCRIPTION
The previous version used an interpolation lib that required `tsc` to be installed globally. This replaces the lib so that builds on Netlify (which don't have a global `tsc`) don't break.

Thanks to a helpful comment from @fuguefoundation on https://github.com/centre-for-effective-altruism/how-rich-am-i/pull/6