### PR TITLE
Show global wealth percentile lower than 1%

### DIFF
--- a/src/lib/calculate/index.js
+++ b/src/lib/calculate/index.js
@@ -93,7 +93,7 @@ export const calculate = ({ income, countryCode, household }) => {
   const internationalizedIncome = internationalizeIncome(income, countryCode)
   const equivalizedIncome = equivalizeIncome(internationalizedIncome, household)
   const convertedIncome = convertIncome(income, countryCode)
-  const incomeCentile = Math.min(99, interpolateIncomeCentileByAmount(equivalizedIncome))
+  const incomeCentile = Math.min(99.9, interpolateIncomeCentileByAmount(equivalizedIncome))
   const incomeTopPercentile = BigNumber(100).minus(incomeCentile).decimalPlaces(1).toNumber()
   const medianMultiple = getMedianMultiple(equivalizedIncome)
 


### PR DESCRIPTION
Currently a income of [$70k](https://howrichami.givingwhatwecan.org/how-rich-am-i?income=70000&countryCode=USA&household%5Badults%5D=1&household%5Bchildren%5D=0) in the US shows that you are in the top 1% globally. It never goes below 1% but interestingly shows a one decimal point when the number is bigger than 1% ([e.g. 50k](https://howrichami.givingwhatwecan.org/how-rich-am-i?income=50000&countryCode=USA&household%5Badults%5D=1&household%5Bchildren%5D=0))

This PR provides a one decimal precision for numbers below 1% as well.
Example: $70k income in the US for a single person household  
<img width="551" alt="Screenshot 2023-10-25 at 18 57 32" src="https://github.com/centre-for-effective-altruism/how-rich-am-i/assets/15565/18d2c4a8-8394-4d5d-b2c5-9be847f47215">
